### PR TITLE
Agregar emburundanguear

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -501,6 +501,21 @@
     ]
   },
   {
+    "text": "Emburundanguear",
+    "meaning": "verbo. Echar burundanga o escopolamina a una persona",
+    "synonyms": [],
+    "examples": [
+      "A ese man lo emburundanguearon",
+      "A la muchacha la emburundanguearon, la robaron y la dejaron tirada"
+    ],
+    "authors": [
+      {
+        "name": "Francisco Quintero",
+        "link": "https://github.com/cesc1989"
+      }
+    ]
+  },
+  {
     "text": "Embuste",
     "meaning": "Mentira o Falsedad",
     "synonyms": [],


### PR DESCRIPTION
_verbo_, Emburundanguear.

Cuando a una persona le echan escopolamina para robarle.